### PR TITLE
Initial Python3 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,4 +29,5 @@ docs/source/pybloqs.htmlconv.rst
 docs/source/pybloqs.plot.rst
 docs/source/pybloqs.rst
 docs/source/pybloqs.static.rst
+.vscode
 

--- a/pybloqs/__init__.py
+++ b/pybloqs/__init__.py
@@ -12,7 +12,7 @@ from pybloqs import plot as bxpl
 try:
     from cStringIO import StringIO
 except ImportError:
-    from StringIO import StringIO
+    from six import StringIO
 
 
 def interactive(verbose=True):

--- a/pybloqs/block/base.py
+++ b/pybloqs/block/base.py
@@ -1,7 +1,7 @@
 import os
 import uuid
 import getpass
-import urlparse
+from six.moves.urllib.parse import urlparse
 import webbrowser
 import tempfile
 
@@ -16,7 +16,7 @@ from pybloqs.html import root, append_to, render, js_elem, id_generator
 try:
     from cStringIO import StringIO
 except ImportError:
-    from StringIO import StringIO
+    from six import StringIO
 
 # Valid page sizes with widths in mm
 _page_width = {

--- a/pybloqs/block/image.py
+++ b/pybloqs/block/image.py
@@ -14,7 +14,7 @@ from pybloqs.util import cfg_to_css_string
 try:
     from cStringIO import StringIO
 except ImportError:
-    from StringIO import StringIO
+    from six import StringIO
 
 
 _MIME_TYPES = {

--- a/pybloqs/block/table.py
+++ b/pybloqs/block/table.py
@@ -105,7 +105,7 @@ class HTMLJinjaTableBlock(BaseBlock):
         """Reformats all but the last header rows."""
         df_clean = self.df.loc[:, self.df.columns.get_level_values(0) != ORG_ROW_NAMES]
         if isinstance(df_clean.columns, pd.MultiIndex):
-            transpose_tuples = zip(*df_clean.columns.tolist())
+            transpose_tuples = list(zip(*df_clean.columns.tolist()))
             header_values = []
             for i, t in enumerate(transpose_tuples):
                 if i < len(transpose_tuples) - 1:

--- a/pybloqs/block/table_formatters.py
+++ b/pybloqs/block/table_formatters.py
@@ -1,6 +1,7 @@
 from collections import namedtuple
 import itertools
 import numbers
+from six import iteritems, string_types
 
 import pybloqs.block.colors as colors
 import numpy as np
@@ -250,7 +251,7 @@ class FmtMultiplyCellValue(TableFormatter):
 
     def _modify_cell_content(self, data):
         """Divide cell value by number"""
-        if (data.row_name == HEADER_ROW_NAME and isinstance(data.cell, basestring)
+        if (data.row_name == HEADER_ROW_NAME and isinstance(data.cell, string_types)
                 and (self.columns is None or data.column_name in self.columns)):
             return data.cell + self.suffix
 
@@ -726,7 +727,7 @@ class FmtAddCellPadding(TableFormatter):
 
     def _create_cell_level_css(self, data):
         css_substrings = []
-        for side, value in self.padding.iteritems():
+        for side, value in iteritems(self.padding):
             if value is not None:
                 css_substrings.append('padding-' + side + ':' + str(value) + self.length_unit)
         return "; ".join(css_substrings)
@@ -749,7 +750,7 @@ class FmtAddCellBorder(TableFormatter):
 
     def _create_cell_level_css(self, data):
         css_substrings = []
-        for side, value in self.padding.iteritems():
+        for side, value in iteritems(self.padding):
             if value is not None:
                 css_substrings.append('border-' + side + ':' + str(value) + self.length_unit + ' ' + self.style + ' '
                                       + colors.css_color(self.color))

--- a/pybloqs/htmlconv/__init__.py
+++ b/pybloqs/htmlconv/__init__.py
@@ -48,7 +48,7 @@ def htmlconv(html_string=None, fmt="pdf", toc=True, tool_args=(), input_file=Non
     if proc.returncode != 0:
         raise ValueError(msg)
     else:
-        print msg
+        print(msg)
 
     # Return the raw output if no output file was provided
     return output, errors

--- a/pybloqs/plot/core.py
+++ b/pybloqs/plot/core.py
@@ -10,11 +10,15 @@ from pybloqs.block.image import ImgBlock
 from pybloqs.html import js_elem, append_to
 from pybloqs.util import camelcase, Cfg, dt_epoch_msecs, np_dt_epoch_msec
 from pybloqs.static import JScript, register_interactive
+from six import text_type, iteritems
 
 try:
     from cStringIO import StringIO
 except ImportError:
-    from StringIO import StringIO
+    from six import StringIO
+import sys
+if sys.version_info > (3,):
+    long = int
 
 
 # Sets of plots based on dimensionality
@@ -292,13 +296,13 @@ class Plot(BaseBlock):
         """
 
         def _decompose_l1(cfg):
-            return [cfg.override_many(data=value).inherit_many(name=key) for key, value in data.iteritems()]
+            return [cfg.override_many(data=value).inherit_many(name=key) for key, value in iteritems(data)]
 
         def _decompose_l2(cfg):
             component_series = []
 
-            for k1, v1 in data.iteritems():
-                for k2, v2 in v1.iteritems():
+            for k1, v1 in iteritems(data):
+                for k2, v2 in iteritems(v1):
                     component_series.append(cfg.override_many(data=v2).inherit_many(name="%s - %s" % (k1, k2)))
 
             return component_series
@@ -436,7 +440,7 @@ class Plot(BaseBlock):
                 stream.write(str(value))
         elif isinstance(value, str):
             stream.write("'" + value + "'")
-        elif isinstance(value, unicode):
+        elif isinstance(value, text_type):
             stream.write("'" + str(value) + "'")
         elif isinstance(value, dict):
             self._write_dict(stream, value)
@@ -474,7 +478,7 @@ class Plot(BaseBlock):
         Write out a dictionary.
         """
         stream.write("{")
-        for i, item in enumerate(dct.iteritems()):
+        for i, item in enumerate(iteritems(dct)):
             # If this is not the first item at this level, prepend a comma
             if i > 0:
                 stream.write(",")

--- a/pybloqs/static/__init__.py
+++ b/pybloqs/static/__init__.py
@@ -8,7 +8,7 @@ from pkg_resources import resource_filename
 try:
     from cStringIO import StringIO
 except ImportError:
-    from StringIO import StringIO
+    from six import StringIO
 
 
 class Resource(object):

--- a/pybloqs/util.py
+++ b/pybloqs/util.py
@@ -3,6 +3,7 @@ import zlib
 import base64
 import calendar
 import itertools
+from six import iterkeys, iteritems
 from io import BytesIO
 
 def dt_epoch_msecs(value):
@@ -57,7 +58,7 @@ def cfg_to_prop_string(cfg, key_transform=lambda k: k, value_transform=lambda v:
 
     Underscores are replaced with dashes and values are converted to lower case.
     """
-    return separator.join(["%s:%s" % (key_transform(key), value_transform(value)) for key, value in cfg.iteritems()])
+    return separator.join(["%s:%s" % (key_transform(key), value_transform(value)) for key, value in iteritems(cfg)])
 
 
 def str_base(num, base=36, numerals="0123456789abcdefghijklmnopqrstuvwxyz"):
@@ -135,7 +136,7 @@ class Cfg(dict):
 
     @staticmethod
     def _mergedicts(dict1, dict2, take_second):
-        for k in set(itertools.chain(dict1.iterkeys(), dict2.iterkeys())):
+        for k in set(itertools.chain(iterkeys(dict1), iterkeys(dict2))):
             if k in dict1 and k in dict2:
                 v1 = dict1[k]
                 v2 = dict2[k]

--- a/tests/integration/generate/test_base.py
+++ b/tests/integration/generate/test_base.py
@@ -3,7 +3,7 @@ import pybloqs.plot as pbp
 
 from pybloqs.block.text import Raw
 from pybloqs.block.base import HRule
-from generation_framework import assert_report_generated
+from .generation_framework import assert_report_generated
 
 HELLO_WORLD = Raw("Hello World!", title="A Title")
 

--- a/tests/integration/generate/test_convenience.py
+++ b/tests/integration/generate/test_convenience.py
@@ -1,7 +1,7 @@
 import pandas as pd
 
 from pybloqs.block.convenience import Block
-from generation_framework import assert_report_generated
+from .generation_framework import assert_report_generated
 
 series = pd.Series([1, 2, 3])
 df = pd.DataFrame({"a": series, "b": series})

--- a/tests/integration/generate/test_image.py
+++ b/tests/integration/generate/test_image.py
@@ -2,7 +2,7 @@ import os
 import pandas as pd
 
 from pybloqs.block.image import PlotBlock, ImgBlock
-from generation_framework import assert_report_generated
+from .generation_framework import assert_report_generated
 
 
 @assert_report_generated

--- a/tests/integration/generate/test_layout.py
+++ b/tests/integration/generate/test_layout.py
@@ -2,7 +2,7 @@ import pandas as pd
 
 from pybloqs.block.text import Span, Raw
 from pybloqs.block.layout import Flow, HStack, VStack, Grid
-from generation_framework import assert_report_generated
+from .generation_framework import assert_report_generated
 
 
 colors = ["Red", "Green", "Blue", "Magenta", "Orange", "Yellow", "Teal"]

--- a/tests/integration/generate/test_plot.py
+++ b/tests/integration/generate/test_plot.py
@@ -2,7 +2,7 @@ import os
 import pandas as pd
 import pybloqs.plot as pbp
 
-from generation_framework import assert_report_generated
+from .generation_framework import assert_report_generated
 
 
 script_dir = os.path.dirname(__file__)

--- a/tests/integration/generate/test_table.py
+++ b/tests/integration/generate/test_table.py
@@ -5,7 +5,7 @@ from pybloqs import Block
 import pybloqs.block.table_formatters as blformat
 import pybloqs.block.colors as colors
 
-from generation_framework import assert_report_generated
+from .generation_framework import assert_report_generated
 
 
 np.random.seed(123)

--- a/tests/integration/generate/test_text.py
+++ b/tests/integration/generate/test_text.py
@@ -1,5 +1,5 @@
 from pybloqs.block.text import Raw, Pre, Span, Markdown
-from generation_framework import assert_report_generated
+from .generation_framework import assert_report_generated
 
 
 @assert_report_generated

--- a/tests/integration/generate/test_wrap.py
+++ b/tests/integration/generate/test_wrap.py
@@ -3,7 +3,7 @@ import pandas as pd
 
 from pybloqs.block.image import ImgBlock
 from pybloqs.block.wrap import Box, Paragraph
-from generation_framework import assert_report_generated
+from .generation_framework import assert_report_generated
 
 
 @assert_report_generated

--- a/tests/unit/test_base_unit.py
+++ b/tests/unit/test_base_unit.py
@@ -2,7 +2,6 @@ import os
 import pybloqs.config as config
 import pybloqs.block.base as bbase
 
-from contextlib import nested
 from mock import patch, MagicMock, ANY, mock_open
 import pytest
 
@@ -35,9 +34,9 @@ def test_show_block_with_env_var():
 
     mock_url = "http://imgur.com/gallery/YLvFFS5/"
 
-    with nested(patch.dict(config.user_config, {"tmp_html_dir": mock_url}, clear=True),
-                patch("webbrowser.open_new_tab"),
-                patch.object(b, "publish")) as (_, tab, pub):
+    with patch.dict(config.user_config, {"tmp_html_dir": mock_url}, clear=True) as _, \
+                patch("webbrowser.open_new_tab") as tab, \
+                patch.object(b, "publish") as pub:
         pub.return_value = "dummy"
 
         b.show()

--- a/tests/unit/test_plot_unit.py
+++ b/tests/unit/test_plot_unit.py
@@ -1,7 +1,7 @@
 from numpy import nan
 from pandas import Series, Index
 from pybloqs.plot import Plot
-from cStringIO import StringIO
+from six import StringIO
 from pytest import fixture
 
 


### PR DESCRIPTION
Resolves all the errors that prevent tests from _running_ in python3. Still contains test _failures_ in python3 (73 fail, 97 pass). Obviously not great, but at least clears out the noise so that specific failures can be addressed. From the few hours I spent on this today, about 90% of the remaining issues are bytes vs strings differences between Python2 and Python3. When we converted Arctic to support Python3 these issues resulted in a lot of changes so I will probably need/want to get some input from the creators before making more changes. 