### PR TITLE
Improve the ability to control an SMTP server login

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,13 +109,31 @@ report.save('report.pdf')
 
 ## Configuration
 
-You can specify per-user default parameters in a yaml-formatted file ~/.pybloqs.cfg:
+You can specify per-user default parameters in a yaml-formatted file ~/.pybloqs.cfg. This
+config file allows you to setup a call setup and login sequence against an smtplib.SMTP (https://docs.python.org/2/library/smtplib.html#smtplib.SMTP)
+object. The following works for Google gmail - more details here (https://support.google.com/a/answer/176600?hl=en)
 ```
-user_email_address: some@email.com  # Default: user name 
-public_dir: /some/dir               # Default: /tmp
-tmp_html_dir: /some/dir             # Default: /tmp
-smtp_server: url.for.email.server   # Default: ''
+smtp_kwargs:
+  host: smtp.gmail.com
+  port: 587
+smtp_pre_login_calls:
+- !!python/tuple
+  - ehlo
+  - {}
+- !!python/tuple
+  - starttls
+  - {}
+- !!python/tuple
+  - ehlo
+  - {}
+smtp_login:
+  user: me@gmail.com
+  password: a_secret
+public_dir: /tmp
+tmp_html_dir: /tmp
+user_email_address: me@gmail.com
 ```
+
 
 ## Documentation
 

--- a/pybloqs/email.py
+++ b/pybloqs/email.py
@@ -46,7 +46,13 @@ def send(message, recipients):
     if not message["To"]:
         message["To"] = ",".join(recipients)
 
-    s = smtplib.SMTP(user_config["smtp_server"])
+    s = smtplib.SMTP(**user_config["smtp_kwargs"])
+    if 'smtp_pre_login_calls' in user_config:
+        smtp_pre_login_calls = user_config['smtp_pre_login_calls']
+        for method, kwargs in smtp_pre_login_calls:
+            getattr(s, method)(**kwargs)
+    if 'smtp_login' in user_config:
+        s.login(**user_config['smtp_login'])
     s.sendmail(message["From"], recipients, message.as_string())
     s.quit()
 

--- a/tests/unit/test_email.py
+++ b/tests/unit/test_email.py
@@ -1,0 +1,51 @@
+from mock import patch, MagicMock, sentinel, call
+import yaml
+from email.message import Message
+from pybloqs.email import send
+
+user_config = \
+    yaml.load(
+        """
+        smtp_kwargs:
+          host: smtp.gmail.com
+          port: 587
+        smtp_pre_login_calls:
+        - !!python/tuple
+          - ehlo
+          - {}
+        - !!python/tuple
+          - starttls
+          - {}
+        - !!python/tuple
+          - ehlo
+          - {}
+        smtp_login:
+          user: djepson@gmail.com
+          password: my_password
+        tmp_html_dir: /tmp
+        user_email_address: me@gmail.com""")
+
+
+def test_send():
+    message = Message()
+    recipients = ['me@gmail.com', 'me@ahl.com']
+    message['From'] = ['origin@gmail.com']
+    message['To'] = recipients
+    message.as_string = MagicMock(return_value=sentinel.message_string)
+    m_SMTP = MagicMock()
+
+    with patch('pybloqs.email.smtplib') as m_smtplib:
+        m_smtplib.SMTP = m_SMTP
+        with patch('pybloqs.email.user_config', user_config):
+            send(message, recipients)
+
+    ex_calls = [
+        call(host='smtp.gmail.com', port=587),
+        call().ehlo(),
+        call().starttls(),
+        call().ehlo(),
+        call().login(password='my_password', user='djepson@gmail.com'),
+        call().sendmail(['origin@gmail.com'], ['me@gmail.com', 'me@ahl.com'], sentinel.message_string),
+        call().quit()]
+
+    assert ex_calls == m_SMTP.mock_calls


### PR DESCRIPTION
Move towards addressing the following issue #29. There may be more to do, but the change is confirmed sufficient to work against gmail SMTP using TLS.