### PR TITLE
Expose original plot format and DPI when setting new ones

### DIFF
--- a/pybloqs/block/image.py
+++ b/pybloqs/block/image.py
@@ -1,5 +1,6 @@
 import base64
 import struct
+from contextlib import contextmanager
 
 import matplotlib.pyplot as plt
 
@@ -30,11 +31,43 @@ _PLOT_MIME_TYPE = _MIME_TYPES[_PLOT_FORMAT]
 _PLOT_DPI = 100
 
 
+@contextmanager
+def plot_format(plot_format=None, dpi=None):
+    """
+    Temporarily set the plot formatting settings
+
+    :param plot_format: The plot format (e.g 'png')
+    :type plot_format:  str
+    :param dpi:         The DPI of the plots
+    :type dpi:          int
+    """
+    old = get_plot_format()
+    set_plot_format(plot_format, dpi)
+    yield
+    set_plot_format(*old)
+
+
+def get_plot_format():
+    """
+    Get the current plot format parameters
+
+    :return: tuple of format and dpi
+    """
+    return _PLOT_FORMAT, _PLOT_DPI
+
+
 def set_plot_format(plot_format=None, plot_dpi=None):
+    """
+    Overwrite the current plot format settings
+
+    :param plot_format: The plot format (e.g. 'png')
+    :type  plot_format: str
+    :param plot_dpi:    The DPI of the plots
+    :type  plot_dpi:    int
+    """
     global _PLOT_FORMAT
     global _PLOT_MIME_TYPE
     global _PLOT_DPI
-
     if plot_format is not None:
         _PLOT_FORMAT = plot_format
         _PLOT_MIME_TYPE = _MIME_TYPES[plot_format]

--- a/tests/unit/test_image_unit.py
+++ b/tests/unit/test_image_unit.py
@@ -1,6 +1,7 @@
 import matplotlib.pyplot as plt
 import pandas as pd
 import pytest
+import pybloqs.block.image as i
 from pybloqs.block.image import PlotBlock, PlotlyPlotBlock
 
 
@@ -32,3 +33,12 @@ def test_create_Plotly_with_invalid_data():
 def test_create_Bokeh_with_invalid_data():
     with pytest.raises(ValueError):
         PlotlyPlotBlock(pd.Series([1, 2, 3]).plot())
+
+
+def test_plot_format_ctx_manager():
+    old_fmt, old_dpi = i._PLOT_FORMAT, i._PLOT_DPI
+    with i.plot_format('svg', 1000):
+        assert i._PLOT_FORMAT == 'svg'
+        assert i._PLOT_DPI == 1000
+    assert i._PLOT_FORMAT == old_fmt
+    assert i._PLOT_DPI == old_dpi


### PR DESCRIPTION
Return the old plot format settings when creating new ones, add context manager to temporarily change plot settings