### PR TITLE
Preserve insertion ordering on dependency tracker

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ defaults: &defaults
          pip install coveralls
          pip install -r docs/source/requirements.txt
          python setup.py install  --highcharts=node_modules/highcharts/,node_modules/highcharts-heatmap/,node_modules/highcharts-funnel,node_modules/highcharts-exporting,node_modules/highcharts-export-csv --wkhtmltopdf=wkhtmltox/bin
-         python setup.py load_highcharts  --highcharts=node_modules/highcharts/js,node_modules/highcharts-heatmap/,node_modules/highcharts-funnel,node_modules/highcharts-exporting,node_modules/highcharts-export-csv
+         python setup.py load_highcharts  --highcharts=node_modules/highcharts/,node_modules/highcharts-heatmap/,node_modules/highcharts-funnel,node_modules/highcharts-exporting,node_modules/highcharts-export-csv
     # Save dependency cache
     - save_cache:
         key: v1-dep-{{ .Branch }}-{{ epoch }}

--- a/pybloqs/static/__init__.py
+++ b/pybloqs/static/__init__.py
@@ -110,13 +110,13 @@ class Css(Resource):
 
 class DependencyTracker(object):
     def __init__(self, *args):
-        self._deps_set = set(args)
+        self._deps = list(args)
 
     def add(self, *resources):
-        self._deps_set = self._deps_set.union(resources)
+        self._deps += [r for r in resources if r not in self._deps]
 
     def __iter__(self):
-        return iter(self._deps_set)
+        return iter(self._deps)
 
 
 # JS deflation script and the reporting core functionality is always registered

--- a/tests/integration/generate/test_base.py
+++ b/tests/integration/generate/test_base.py
@@ -13,7 +13,7 @@ def _create_dynamic_content():
     d = pd.date_range("2012-01-01", periods=10)
     s = pd.Series(range(len(d)), d)
 
-    return pbp.Plot(s, width="100%", height="100%")
+    return pbp.Plot(s, width="100px", height="100%")
 
 
 @assert_report_generated

--- a/tests/unit/static/test_static.py
+++ b/tests/unit/static/test_static.py
@@ -100,10 +100,10 @@ def test_dependency_tracker_add_resources_with_deduplication():
 
 
 def test_dependency_tracker_insertion_order():
-    dep = ps.DependencyTracker('A', 'B')
-    dep.add('C')
+    dep = ps.DependencyTracker('A', 'C')
     dep.add('D')
-    assert list(dep) == ['A', 'B', 'C', 'D']
+    dep.add('B')
+    assert list(dep) == ['A', 'C', 'D', 'B']
 
 
 def test_register_interactive_write_interactive():

--- a/tests/unit/static/test_static.py
+++ b/tests/unit/static/test_static.py
@@ -93,10 +93,17 @@ def test_dependency_tracker_retrieve_resources():
     assert set(dep) == {'res1', 'res2'}
 
 
-def test_dependency_tracker_add_resources_wit_deduplication():
-    dep = ps.DependencyTracker()
+def test_dependency_tracker_add_resources_with_deduplication():
+    dep = ps.DependencyTracker('res1')
     dep.add('res1', 'res2', 'res1')
-    assert set(dep) == {'res1', 'res2'}
+    assert sorted(dep) == ['res1', 'res2']
+
+
+def test_dependency_tracker_insertion_order():
+    dep = ps.DependencyTracker('A', 'B')
+    dep.add('C')
+    dep.add('D')
+    assert list(dep) == ['A', 'B', 'C', 'D']
 
 
 def test_register_interactive_write_interactive():


### PR DESCRIPTION
Else cross-script dependencies break in jupyter notebooks (but curiously not in lab)