### PR TITLE
Bug: Mixed datatypes in totals row formatter give NaN instead empty

### DIFF
--- a/pybloqs/block/table_formatters.py
+++ b/pybloqs/block/table_formatters.py
@@ -571,9 +571,10 @@ class FmtAppendTotalsRow(TableFormatter):
         else:
             columns = self.total_columns
         if self.operator is not OP_NONE:
-            last_row = self.operator(df[df.applymap(np.isreal)])
+            df_calculated = df[columns]
+            last_row = self.operator(df_calculated[df_calculated.applymap(np.isreal)])
             last_row = last_row.fillna(0.)
-            last_row[~last_row.index.isin(columns)] = ''
+            last_row = last_row.append(pd.Series('', index=df.columns.difference(last_row.index)))
         else:
             last_row = pd.Series('', index=df.columns)
         last_row.name = self.row_name

--- a/tests/unit/block/test_table_formatters.py
+++ b/tests/unit/block/test_table_formatters.py
@@ -515,6 +515,14 @@ def test_FmtAppendTotalsRow_modify_dataframe():
     assert expected.equals(res.ix[-1])
 
 
+def test_FmtAppendTotalsRow_mixed_datatypes():
+    df = pd.util.testing.makeMixedDataFrame()
+    fmt = pbtf.FmtAppendTotalsRow(total_columns=['A'])
+    res = fmt._modify_dataframe(df)
+    last_row_expected = pd.Series({'A': 10., 'B': '', 'C': '', 'D': ''}, name="Total")
+    pd.util.testing.assert_series_equal(res.iloc[-1], last_row_expected)
+
+
 def test_FmtAppendTotalsRow_cell_css():
     row_name = TEST_STRING
     fmt = pbtf.FmtAppendTotalsRow(row_name=row_name)


### PR DESCRIPTION
Non-numeric data types would not have been in last_row and appending last_row would then create NaNs in the dataframe.